### PR TITLE
container/lighttpd: Add image build option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,21 +27,41 @@ example](https://github.com/BobBuildTool/bob-example-embedded).
 
 # How to build
 
-Clone the recipes and build them with Bob:
+First of all you have to clone the recipes and change to the checked-out
+directory:
 
     $ git clone https://github.com/BobBuildTool/bob-example-containers.git \
 	    --recurse-submodules
     $ cd bob-example-containers
+
+The next steps depend on what you want to build.
+
+## Docker Container
+
+These recipes can build a minimal container image that has solely lighttpd and
+the required dependencies installed by running the following command:
+
+    $ # Still in the bob-example-containers directory
     $ bob build containers::lighttpd
 
-These recipes build a minimal container image that has solely lighttpd and the
-required dependencies installed.
+## Systemd Portable Service
+
+These recipes can also provide a systemd portable service that can be attached
+with `portablectl` by issuing the following command:
+
+    $ # Still in the bob-example-containers directory
+    $ bob build containers::lighttpd-image
 
 # How to use
 
+Again, usage of the build products depends on the chosen target.
+
+## Docker Container
+
 To use it you have to import it in Docker:
 
-    $ # Still in the bob-example-containers directory
+    $ # Still in the bob-example-containers directory after building
+    $ # containers::lighttpd
     $ tar -C $(bob query-path -f '{dist}' --release containers::lighttpd) -c . \
         | docker import - lighttpd
 
@@ -52,6 +72,20 @@ Now you can serve any host directory with the lighttpd in the image:
         -m /usr/lib/lighttpd
 
 This will expose the lighttpd at port 8080 on your host.
+
+## Systemd Portable Service
+
+First you have to import the portable service:
+
+    $ # Still in the bob-example-containers directory after building
+    $ # containers::lighttpd-image
+    $ portablectl attach $(bob query-path -f '{dist}' --release containers::lighttpd-image)/lighttpd.raw
+
+Now you can start the lighttpd as any other systemd service on your host:
+
+    $ systemctl start lighttpd.service
+
+lighttpd should now listen on port 80.
 
 # Contributions
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,3 @@
-bobMinimumVersion: "0.15"
+bobMinimumVersion: "0.16rc1"
 layers:
     - basement

--- a/recipes/containers/lighttpd.yaml
+++ b/recipes/containers/lighttpd.yaml
@@ -39,5 +39,36 @@ buildScript: |
     lighttpd:x:33:
     EOF
 
-packageScript: |
-    cp -a $1/* .
+
+multiPackage:
+    "":
+        packageScript: |
+            cp -a $1/* .
+
+    image:
+        buildTools: [squashfs-tools]
+        buildScript: |
+            # Remove username and group because the systemd.service already
+            # takes care of this.
+            sed -i -e '/server.username/d' -e '/server.groupname/d' \
+                etc/lighttpd/lighttpd.conf
+
+            # See https://systemd.io/PORTABLE_SERVICES.html
+            mkdir -p etc/systemd/system
+            install -m 644 $<<lighttpd/lighttpd.service>> \
+                            etc/systemd/system/lighttpd.service
+            install -m 644 $<<lighttpd/lighttpd.socket>> \
+                            etc/systemd/system/lighttpd.socket
+            touch etc/machine-id
+            ln -s ../usr/lib/os-release etc/os-release
+            touch etc/resolv.conf
+            mkdir -p proc sys dev run tmp usr/lib var/tmp
+            cat >usr/lib/os-release <<EOF
+            NAME="lighttpd"
+            PRETTY_NAME="Bob lighttpd container example"
+            ID=linux
+            HOME_URL="https://github.com/BobBuildTool/bob-example-containers"
+            EOF
+
+        packageScript: |
+            mksquashfs $1 lighttpd.raw

--- a/recipes/containers/lighttpd.yaml
+++ b/recipes/containers/lighttpd.yaml
@@ -39,6 +39,9 @@ buildScript: |
     lighttpd:x:33:
     EOF
 
+    # Default landing page
+    mkdir -p srv/www
+    install -m 644 $<<lighttpd/index.html>> srv/www/index.html
 
 multiPackage:
     "":

--- a/recipes/containers/lighttpd.yaml
+++ b/recipes/containers/lighttpd.yaml
@@ -45,6 +45,11 @@ buildScript: |
 
 multiPackage:
     "":
+        buildScript: |
+            # PID file
+            mkdir -p run/lighttpd
+            touch run/lighttpd/lighttpd.pid
+
         packageScript: |
             cp -a $1/* .
 

--- a/recipes/containers/lighttpd/index.html
+++ b/recipes/containers/lighttpd/index.html
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+         "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+ <head>
+  <title>lighttpd works</title>
+ </head>
+ <body>
+  <h1>It works!</h1>
+  Looks like the lighttpd service is working.
+  <h1>Configuration needed</h1>
+  <h2>Systemd portable service</h2>
+  In order to serve something useful with the portable lighttpd service
+  you must bind the document root directory to /srv/www. This done by
+  adding a drop-in with a <code>BindReadOnlyPaths=</code>, e.g.:
+<pre>
+# systemctl edit lighttpd.service
+[Service]
+BindReadOnlyPaths=&lt;your-html-dir&gt;:/srv/www
+</pre>
+  Then restart the service and you should see your documents.
+  <h2>Docker container</h2>
+  When running the docker container you should add the proper <code>-v</code>
+  option to the command line, e.g.:
+<pre>
+$ docker run -v &lt;your-html-dir&gt;:/srv/www lighttpd ...
+</pre>
+ </body>
+</html>
+

--- a/recipes/containers/lighttpd/index.html
+++ b/recipes/containers/lighttpd/index.html
@@ -1,30 +1,27 @@
-<?xml version="1.0" encoding="iso-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-         "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
- <head>
-  <title>lighttpd works</title>
- </head>
- <body>
-  <h1>It works!</h1>
-  Looks like the lighttpd service is working.
-  <h1>Configuration needed</h1>
-  <h2>Systemd portable service</h2>
-  In order to serve something useful with the portable lighttpd service
-  you must bind the document root directory to /srv/www. This done by
-  adding a drop-in with a <code>BindReadOnlyPaths=</code>, e.g.:
-<pre>
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>lighttpd works</title>
+    </head>
+    <body>
+        <h1>It works!</h1>
+        Looks like the lighttpd service is working.
+        <h2>Configuration needed</h2>
+        <h3>Systemd portable service</h3>
+        In order to serve something useful with the portable lighttpd service
+        you must bind the document root directory to <code>/srv/www</code>. This
+        done by adding a drop-in with a <code>BindReadOnlyPaths=</code>, e.g.:
+        <pre>
 # systemctl edit lighttpd.service
 [Service]
 BindReadOnlyPaths=&lt;your-html-dir&gt;:/srv/www
-</pre>
-  Then restart the service and you should see your documents.
-  <h2>Docker container</h2>
-  When running the docker container you should add the proper <code>-v</code>
-  option to the command line, e.g.:
-<pre>
+        </pre>
+        Then restart the service and you should see your documents.
+        <h3>Docker container</h3>
+        When running the docker container you should add the proper
+        <code>-v</code> option to the command line, e.g.:
+        <pre>
 $ docker run -v &lt;your-html-dir&gt;:/srv/www lighttpd ...
-</pre>
- </body>
+        </pre>
+    </body>
 </html>
-

--- a/recipes/containers/lighttpd/lighttpd.conf
+++ b/recipes/containers/lighttpd/lighttpd.conf
@@ -2,7 +2,7 @@
 
 var.log_root    = "/var/log/lighttpd"
 var.server_root = "/srv/www"
-var.state_dir   = "/var/run"
+var.state_dir   = "/run/lighttpd"
 var.home_dir    = "/var/lib/lighttpd"
 var.conf_dir    = "/etc/lighttpd"
 
@@ -14,6 +14,7 @@ server.username  = "lighttpd"
 server.groupname = "lighttpd"
 server.document-root = server_root
 server.pid-file = state_dir + "/lighttpd.pid"
+server.systemd-socket-activation = "enable"
 
 server.errorlog             = log_root + "/error.log"
 

--- a/recipes/containers/lighttpd/lighttpd.service
+++ b/recipes/containers/lighttpd/lighttpd.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=A secure, fast, compliant and very flexible web-server
+After=syslog.target network.target lighttpd.socket
+Requires=lighttpd.socket
+
+
+[Service]
+Type=simple
+PIDFile=/run/lighttpd/lighttpd.pid
+ExecStartPre=/usr/sbin/lighttpd -tt -f /etc/lighttpd/lighttpd.conf
+ExecStart=/usr/sbin/lighttpd -D -f /etc/lighttpd/lighttpd.conf
+ExecReload=/bin/kill -USR1 $MAINPID
+Restart=on-failure
+
+User=lighttpd
+Group=lighttpd
+DynamicUser=yes
+
+RuntimeDirectory=lighttpd
+LogsDirectory=lighttpd

--- a/recipes/containers/lighttpd/lighttpd.socket
+++ b/recipes/containers/lighttpd/lighttpd.socket
@@ -1,0 +1,8 @@
+[Unit]
+Description=lighttpd socket
+
+[Socket]
+ListenStream=80
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
The image includes files needed by the host systemd in order to be able
to automatically "attach" lighttpd to the host as a "portable service".

In order to use the host paths enforced by the host systemd, changes to
the lighttpd.conf were necessary, as well.

These changes are WIP since I haven't been able to test them with a
recent enough systemd. The mounted images looks good, though.

This needs BobBuildTool/basement#5